### PR TITLE
Přeložit UI editoru menu do češtiny

### DIFF
--- a/menu/index.html
+++ b/menu/index.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="cs">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Modern Vanilla Menu Editor</title>
+    <title>Editor menu</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="menu-editor">
         <header class="top-bar">
-            <h2>Navigation Editor</h2>
+            <h2>Editor navigace</h2>
             <div class="actions">
-                <button id="btn-undo" type="button" class="btn btn-secondary" disabled title="Undo" aria-label="Undo">↩</button>
-                <button id="btn-redo" type="button" class="btn btn-secondary" disabled title="Redo" aria-label="Redo">↪</button>
-                <button id="btn-add" class="btn btn-primary">+ Add New Item</button>
-                <button id="btn-save" class="btn btn-success" disabled>Save Menu</button>
+                <button id="btn-undo" type="button" class="btn btn-secondary" disabled title="Zpět" aria-label="Zpět">↩</button>
+                <button id="btn-redo" type="button" class="btn btn-secondary" disabled title="Znovu" aria-label="Znovu">↪</button>
+                <button id="btn-add" class="btn btn-primary">+ Přidat položku</button>
+                <button id="btn-save" class="btn btn-success" disabled>Uložit menu</button>
             </div>
         </header>
 
@@ -26,28 +26,28 @@
         <li class="menu-item" data-depth="0">
             <div class="item-header">
                 <div class="drag-handle">⠿</div>
-                <span class="item-title-display">New Item</span>
+                <span class="item-title-display">Nová položka</span>
                 <button class="btn-expand">▼</button>
             </div>
             <div class="item-settings">
                 <div class="input-group">
-                    <label>Navigation Label</label>
-                    <input type="text" class="input-title" value="New Item">
+                    <label>Název v navigaci</label>
+                    <input type="text" class="input-title" value="Nová položka">
                 </div>
                 <div class="input-group">
                     <label>URL</label>
                     <input type="text" class="input-url" placeholder="https://...">
                 </div>
                 <div class="item-quick-nav">
-                    <button class="btn-move-up">↑ Move up</button>
-                    <button class="btn-move-down">↓ Move down</button>
-                    <button class="btn-increase-level">→ Increase level</button>
-                    <button class="btn-decrease-level">← Decrease level</button>
-                    <button class="btn-to-top">⇈ To the top</button>
-                    <button class="btn-to-bottom">⇊ To the bottom</button>
+                    <button class="btn-move-up">↑ Posunout výš</button>
+                    <button class="btn-move-down">↓ Posunout níž</button>
+                    <button class="btn-increase-level">→ Zanořit pod předchozí</button>
+                    <button class="btn-decrease-level">← Posunout o úroveň výš</button>
+                    <button class="btn-to-top">⇈ Přesunout na začátek</button>
+                    <button class="btn-to-bottom">⇊ Přesunout na konec</button>
                 </div>
-                <button class="btn-remove">Remove Item</button>
-                <button class="btn-duplicate">Duplicate Item</button>
+                <button class="btn-remove">Smazat položku</button>
+                <button class="btn-duplicate">Duplikovat položku</button>
             </div>
         </li>
     </template>

--- a/menu/script.js
+++ b/menu/script.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let isDragging = false;
     let dragStartCandidate = null;
 
-    // --- Undo/Redo History ---
+    // --- Historie zpět/znovu ---
     const MAX_HISTORY = 50;
     let historyStack = [];
     let historyIndex = -1;
@@ -96,7 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
         restoreSnapshot(historyStack[historyIndex]);
     });
 
-    // --- Unsaved Changes Warning ---
+    // --- Upozornění na neuložené změny ---
     window.addEventListener('beforeunload', (e) => {
         if (isDirty()) {
             e.preventDefault();
@@ -104,13 +104,13 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Load existing data or start empty
+    // Načíst existující data nebo začít s prázdným menu
     loadMenu();
 
-    // --- UI Interactions ---
+    // --- Interakce UI ---
     btnAdd.addEventListener('click', () => {
         const id = generateId();
-        const newItem = createMenuItem(id, 'New Item', '', 0);
+        const newItem = createMenuItem(id, 'Nová položka', '', 0);
         menuList.appendChild(newItem);
         pushHistory();
     });
@@ -129,7 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
         li.querySelector('.input-title').value = title;
         li.querySelector('.input-url').value = url;
 
-        // Setup Accordion Toggle
+        // Přepínání rozbalení nastavení
         li.querySelector('.btn-expand').addEventListener('click', (e) => {
             if (isDragging) return;
             const settings = li.querySelector('.item-settings');
@@ -137,22 +137,22 @@ document.addEventListener('DOMContentLoaded', () => {
             e.target.textContent = settings.classList.contains('expanded') ? '▲' : '▼';
         });
 
-        // Setup Live Title Update
+        // Živá aktualizace názvu
         li.querySelector('.input-title').addEventListener('input', (e) => {
-            li.querySelector('.item-title-display').textContent = e.target.value || '(No Label)';
+            li.querySelector('.item-title-display').textContent = e.target.value || '(Bez názvu)';
         });
 
-        // Track title/url changes for undo history
+        // Sledování změn názvu/URL pro historii
         li.querySelector('.input-title').addEventListener('change', () => pushHistory());
         li.querySelector('.input-url').addEventListener('change', () => pushHistory());
 
-        // Setup Remove
+        // Odebrání položky
         li.querySelector('.btn-remove').addEventListener('click', () => {
             li.remove();
             pushHistory();
         });
 
-        // Setup Duplicate
+        // Duplikování položky
         li.querySelector('.btn-duplicate').addEventListener('click', () => {
             const dupTitle = li.querySelector('.input-title').value;
             const dupUrl = li.querySelector('.input-url').value;
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 settings.classList.contains('expanded') ? '▲' : '▼';
         });
 
-        // Setup Quick Navigation
+        // Rychlá navigace položky
         li.querySelector('.btn-move-up').addEventListener('click', () => {
             const items = [...menuList.querySelectorAll('.menu-item:not(.placeholder)')];
             const index = items.indexOf(li);
@@ -269,7 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const lastIndex = items.indexOf(lastItem);
             if (lastIndex === items.length - 1) return;
             const newPrevItem = items[lastIndex + 1];
-            // Move after the entire newPrevItem subtree to avoid splitting it
+            // Přesunout za celý podstrom předchozí položky, aby se nerozdělil
             const newPrevSubtree = getSubtree(newPrevItem);
             const newPrevBlockLast = newPrevSubtree.length > 0 ? newPrevSubtree[newPrevSubtree.length - 1] : newPrevItem;
             newPrevBlockLast.after(li, ...subtree);
@@ -514,8 +514,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const offsetX = e.clientX - listRect.left;
         let requestedDepth = Math.floor(offsetX / INDENT_SIZE);
         
-        // 3. Apply WordPress Constraints: 
-        // Cannot be deeper than (Previous Item's Depth + 1). Root items are 0.
+        // 3. Použít omezení zanoření: 
+        // Nelze jít hlouběji než (úroveň předchozí položky + 1). Kořen je úroveň 0.
         let maxDepth = 0;
         let prevItem = placeholder.previousElementSibling;
         while (prevItem && prevItem.classList.contains('dragging')) {
@@ -585,11 +585,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function saveMenu() {
         const items = [...menuList.querySelectorAll('.menu-item:not(.placeholder)')];
         const menuData = items.map((item, index) => {
-            // Calculate parent based on depth logic
+            // Vypočítat rodiče podle úrovně zanoření
             const depth = parseInt(item.dataset.depth);
             let parentId = null;
             
-            // Search upwards for the nearest item with a lesser depth
+            // Hledat směrem nahoru nejbližší položku s menší úrovní
             for (let i = index - 1; i >= 0; i--) {
                 if (parseInt(items[i].dataset.depth) < depth) {
                     parentId = items[i].dataset.id;
@@ -611,9 +611,9 @@ document.addEventListener('DOMContentLoaded', () => {
         savedIndex = historyIndex;
         updateSaveButton();
         
-        // Quick visual feedback
+        // Krátká vizuální zpětná vazba
         const originalText = btnSave.textContent;
-        btnSave.textContent = 'Saved!';
+        btnSave.textContent = 'Uloženo!';
         btnSave.style.background = '#047857';
         setTimeout(() => {
             btnSave.textContent = originalText;
@@ -631,11 +631,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     menuList.appendChild(item);
                 });
             } catch (e) {
-                console.error("Failed to parse menu data", e);
+                console.error("Nepodařilo se načíst data menu", e);
             }
         }
         pushHistory();
-        savedIndex = historyIndex; // Loaded state matches what's in localStorage
+        savedIndex = historyIndex; // Načtený stav odpovídá datům v localStorage
         updateSaveButton();
     }
 });


### PR DESCRIPTION
### Motivation
- Lokalizovat uživatelské rozhraní editoru menu v `/menu/` do češtiny, aby byly popisky a akce srozumitelné koncovému uživateli.
- Nahradit technické/implementační názvy (např. `Increase level` / `Decrease level`) uživatelsky logickými popisky.
- Odstranit zmínky o WordPress v komentářích a textových řetězcích, aby kód nebyl závislý na terminologii platformy.

### Description
- Aktualizováno `menu/index.html`: nastaveno `lang="cs"`, změněn `title`, nadpis editoru, texty v horní liště a všechny texty v položkové šabloně (např. výchozí název, popisky polí a tlačítek).
- Přepsány názvy rychlých akcí pro úrovně: `Increase level` → `Zanořit pod předchozí` a `Decrease level` → `Posunout o úroveň výš` v `menu/index.html`.
- Lokalizovány texty v `menu/script.js`: výchozí hodnota `Nová položka`, fallback label `'(Bez názvu)'`, uložená zpětná vazba `Uloženo!` a chybová zpráva v konzoli `Nepodařilo se načíst data menu` a upraveny komentáře (odstraněna zmínka o WordPress).
- Změny jsou čistě textové a komentářové bez zásahu do logiky přesouvání/uložení položek; upravené soubory jsou `menu/index.html` a `menu/script.js`.

### Testing
- Spuštěna kontrola syntaxe JavaScriptu pomocí `node --check menu/script.js`, která proběhla úspěšně.
- Ověřeno vyhledáním `WordPress|wordpress` v `menu/index.html` a `menu/script.js` pomocí `rg`, žádné výskyty nebyly nalezeny.
- Pokus o automatizovaný screenshot stránky přes Playwright selhal kvůli prostředí s chybou (`ERR_EMPTY_RESPONSE`), viz logy pro detail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9622909d08328a3f98d3aba9b4aae)